### PR TITLE
Notebooks updates for opening 

### DIFF
--- a/EDEN/EDEN-example.ipynb
+++ b/EDEN/EDEN-example.ipynb
@@ -13,13 +13,9 @@
    "source": [
     "# How to discover and access data from DestinE Platform\n",
     "\n",
-    "## Prerequirements\n",
-    "### Select kernel\n",
-    "Select the kernel `my_env` from the top-right menu of this notebook.\n",
+    "## Prerequisites: DESP credentials\n",
     "\n",
-    "### Get the credentials to access EDEN\n",
-    "You need to have an account on the [Destination Earth Platform](https://auth.destine.eu/realms/desp/account). \n",
-    "Follow notebooks steps to insert credentials and access the data."
+    "You need to have an account on the [Destination Earth Platform](https://auth.destine.eu/realms/desp/account)"
    ]
   },
   {
@@ -87,7 +83,7 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdin",
+     "name": "stdout",
      "output_type": "stream",
      "text": [
       "Type your username :  ········\n",
@@ -360,7 +356,7 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdin",
+     "name": "stdout",
      "output_type": "stream",
      "text": [
       "which of the displayed 10 products do you want to download? (type one number in the range 1-10) :  10\n"

--- a/README.md
+++ b/README.md
@@ -6,35 +6,38 @@ This set of Jupyter Notebook tutorials equips users with the skills to access an
 * [How to access LUMI's Extremes Digital Twin data using earthkit and the Polytope API](./polytope/polytope-earthkit.ipynb): this example supports the user to retrieve Weather Extremes DT data from Polytope and visualize it.
 * [How to discover and access data from DestinE Platform](./EDEN/EDEN-example.ipynb): this example supports the user in discover and access DestinE data through EDEN Service.
 
-## Installation
-The collection of Jupyter Notebooks tutorials is seamlessly integrated into your personal Insula Code Lab user environment. To execute these tutorials, simply follow the instructions provided below to install a Python virtual environment.
-### Create a virtual environment
-Open a Terminal window and create a virtual environment named `getting_started`: 
-```
-python -m venv /home/jovyan/getting_started
-```
-Activate it:
-```
-source /home/jovyan/getting_started/bin/activate
-```
-### Install dependencies
-We collected the needed dependencies in the requirements file `requirements.txt` [here](./requirements.txt). Install these dependencies within the `getting_started` created at the step above.
-```
-pip install -r requirements.txt
-```
-> **Note**: These requirements are frozen as of the latest update of this repository, meaning the module versions specified reflect a snapshot of dependencies at that specific point in time.
-
-Install the Jupyter kernel `getting_started`:
-```
-ipython kernel install --user --name=getting_started
-```
-> **Note**: Do not forget to change the kernel to `getting_started` every time you want to run the Insula Code Lab Jupyter tutorials.
-
 ## Credits
 
 * `cacheb-climate-example.ipynb` and `cacheb-authentication` original content created by B-Open (Earth Data Hub). 
 * `polytope-earthkit.ipynb` and `desp-authentication.py` are a slightly modified version of the examples available at [Destination Earth Digital Twins's polytope examples](https://github.com/destination-earth-digital-twins/polytope-examples/) by ECMWF.
 * `EDEN-example.ipynb` and `auth.py` original content created by MEEO (EDEN).
+
+## Installation
+The collection of Jupyter Notebooks tutorials is seamlessly integrated into the Insula Code Lab Python environment for all users. Installed Python dependencies are provided in the file [requirements.txt](./requirements.txt) .
+
+More expert users can create their own Python virtual environment following the instructions provided below.
+### Create a virtual environment
+Open a Terminal window and create a virtual environment named `my_env`: 
+```
+python -m venv /home/jovyan/my_env
+```
+Activate it:
+```
+source /home/jovyan/my_env/bin/activate
+```
+### Install dependencies
+Users can install Python dependencies via `pip` channel singularly or in a batch by means of a `requirements.txt` file:
+
+```
+pip install -r requirements.txt
+```
+> **Note**: Pre-installed Python requirements are frozen as of the latest release of Insula Code Lab, meaning package versions reflect a snapshot of dependencies currently running in the user environment.
+
+Install the Jupyter kernel `my_env`:
+```
+ipython kernel install --user --name=my_env
+```
+> **Note**: Do not forget to change the kernel to `my_env` using the upper-right button within the Jupyter user interface every time you want to run your code.
 
 ## Contact
 If you have questions or need support with these examples, contact the support at https://platform.destine.eu/support.

--- a/cacheb/cacheb-climate-example.ipynb
+++ b/cacheb/cacheb-climate-example.ipynb
@@ -13,21 +13,10 @@
    "id": "990e6a7c-0fa0-46b9-b177-ac3f3f57d87b",
    "metadata": {},
    "source": [
-    "## Prerequisites \n",
+    "## Prerequisites\n",
+    "### DESP Credentials\n",
     "\n",
-    "### Select kernel\n",
-    "\n",
-    "Select the kernel `my_env` from the top-right menu of this notebook\n",
-    "\n",
-    "### Get the credentials to access the DESP CacheB\n",
-    "\n",
-    "You need to have an account on the [Destination Earth Platform](https://auth.destine.eu/realms/desp/account)\n",
-    "\n",
-    "Open the Terminal and run:\n",
-    "```\n",
-    "python cacheb-authentication.py -u username -p password >> ~/.netrc`\n",
-    "```\n",
-    "**NOTE: the temporary password is valid for a limited period of time and needs to be regenerated and reconfigured periodically.**"
+    "You need to have an account on the [Destination Earth Platform](https://auth.destine.eu/realms/desp/account)"
    ]
   },
   {
@@ -36,7 +25,7 @@
    "metadata": {},
    "source": [
     "## Access the Data\n",
-    "After the configuration you can access the dataset in the CacheB cache with Xarray / Zarr.\n",
+    "With a DESP account you can access the dataset in the CacheB cache with Xarray / Zarr.\n",
     "\n",
     "Here below the list of available datasets, they are all reachable via a dedicated URL. In the following example we will work only with the Climate DT high resolution surface with hourly resolution, on atmosphere variables."
    ]
@@ -59,6 +48,40 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "1e71b840",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%capture cap\n",
+    "%run ./cacheb-authentication.py"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "51b53ed4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "output_1 = cap.stdout.split('}\\n')\n",
+    "token = output_1[-1][0:-1]\n",
+    "\n",
+    "from pathlib import Path\n",
+    "with open(Path.home() / \".netrc\", \"a\") as fp:\n",
+    "    fp.write(token)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "033a05bd",
+   "metadata": {},
+   "source": [
+    "**NOTE**: the temporary password is valid for a limited period of time and needs to be regenerated and reconfigured periodically by running the cells above."
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 2,
    "id": "d6376bac-fb44-4d19-9e49-70760aa0c207",
    "metadata": {
@@ -68,7 +91,7 @@
    "source": [
     "import xarray as xr\n",
     "data = xr.open_dataset(\n",
-    "        \"https://cacheb.dcms.destine.eu/destine-climate-dt/SSP3-7.0-IFS-NEMO-0001-high-sfc-v0.zarr\",\n",
+    "        \"https://cacheb.dcms.destine.eu/d1-climate-dt/ScenarioMIP-SSP3-7.0-IFS-NEMO-0001-high-sfc-v0.zarr\",\n",
     "        engine=\"zarr\",\n",
     "        storage_options={\"client_kwargs\": {\"trust_env\": \"true\"}},\n",
     "        chunks={},\n",

--- a/requirements.txt
+++ b/requirements.txt
@@ -60,12 +60,14 @@ importlib_metadata==7.1.0
 iniconfig==2.0.0
 ipykernel==6.29.4
 ipython==8.23.0
+ipywidgets==8.1.3
 jedi==0.19.1
 Jinja2==3.1.3
 jsonschema==4.21.1
 jsonschema-specifications==2023.12.1
 jupyter_client==8.6.1
 jupyter_core==5.7.2
+jupyterlab_widgets==3.0.11
 kiwisolver==1.4.5
 llvmlite==0.42.0
 locket==1.0.0
@@ -152,6 +154,7 @@ tzdata==2024.1
 urllib3==2.2.1
 virtualenv==20.26.0
 wcwidth==0.2.13
+widgetsnbextension==4.0.11
 xarray==2024.3.0
 xyzservices==2024.4.0
 yarl==1.9.4


### PR DESCRIPTION
The following changes have been performed
* README updated, some details removed and aligned with the release 2.0 (venv image)
* cacheb-notebook modified including the management of the authentication script via notebook cell (before was via CLI)
* cacheb-notebook prehamble modified, aligned with the venv image
* EDEN notebook prehamble modified, aligned with the venv image